### PR TITLE
Update 2021-10-23-less-known-capability-of-rubys-json-dot-parse.md

### DIFF
--- a/posts/2021-10-23-less-known-capability-of-rubys-json-dot-parse.md
+++ b/posts/2021-10-23-less-known-capability-of-rubys-json-dot-parse.md
@@ -14,6 +14,9 @@ If you ever got annoyed by the fact that `JSON.parse` returns hash with string k
 If you're a Rails developer, you're probably familiar with `deep_symbolize_keys` method in `Hash` which can help with such case. Especially, in ideal world, where our data structure is a hash, like:
 
 ```ruby
+# if outside of Rails, add the below require statement
+#require 'json'
+
 json = <<~JSON
 { 
   foo: {


### PR DESCRIPTION
I tried to play around with the above code both in a IRB session and in a simple *.rb file to check it out. It seems like you should always require 'json' on the top of the file except if you use `-r` option when running it from the command line. The same comes for an IRB session.