### PR TITLE
Optimize query

### DIFF
--- a/posts/2017-10-06-rails-how-to-find-records-where-column-is-not-null-or-empty.md
+++ b/posts/2017-10-06-rails-how-to-find-records-where-column-is-not-null-or-empty.md
@@ -27,7 +27,7 @@ User.where(category: [nil, ""])
 Still easy.
 
 ```ruby
-User.where.not(category: [nil, ""])
+User.where.not(category: "")
 ```
 
 This `not()` clause is going to only apply to one `where`. You are not going to negate all previous conditions. In other words you can safely use it like this:


### PR DESCRIPTION
`User.where.not(category: "")` will also find records where column is not null or empty (`SELECT "users".* FROM "users" WHERE "users"."category" != ?  [["category", ""]`) but in a more efficient way than using the array form (`NOT IN`). 
Because of the nature of `not`, it does not fetch records where `category` is `null`. You can read more about this topic in https://thoughtbot.com/blog/activerecord-s-where-not-and-nil