### PR TITLE
Improve 2024-03-29-replace-aasm-with-rails-enum-today.md

### DIFF
--- a/posts/2024-03-29-replace-aasm-with-rails-enum-today.md
+++ b/posts/2024-03-29-replace-aasm-with-rails-enum-today.md
@@ -123,10 +123,10 @@ We can do even better by removing unnecessary boilerplate. This in turn will mak
 ```ruby
 class Transaction < ApplicationRecord
     STATUSES = [
-      PROCESSING = :processing,
-      FAILED = :failed,
-      SUCCESSFUL = :successful,
-      CANCELED = :canceled,
+        PROCESSING = :processing,
+        FAILED = :failed,
+        SUCCESSFUL = :successful,
+        CANCELED = :canceled,
     ]
 
     enum :status,
@@ -137,6 +137,14 @@ end
 ```
 
 We define constants that hold the valid status values and use the return values of these definitions as elements of an array of statuses.
+
+This is possible since constant assignment returns the assigned value.
+
+```ruby
+puts(FOO = "bar")
+#=> bar
+```
+
 We can later on use `reduce` on this array when defining the enum to construct a `Hash` that maps symbol statuses to strings.
 This ensures that we have only a single place that we need to modify when adding, deleting or changing the possible statuses.
 

--- a/posts/2024-03-29-replace-aasm-with-rails-enum-today.md
+++ b/posts/2024-03-29-replace-aasm-with-rails-enum-today.md
@@ -116,6 +116,30 @@ end
 
 That’s it. Quit clean and understandable, isn’t it?
 
+### Less boilerplate
+
+We can do even better by removing unnecessary boilerplate. This in turn will make refactoring and adding new statuses a lot easier.
+
+```ruby
+class Transaction < ApplicationRecord
+    STATUSES = [
+      PROCESSING = :processing,
+      FAILED = :failed,
+      SUCCESSFUL = :successful,
+      CANCELED = :canceled,
+    ]
+
+    enum :status,
+         STATUSES.reduce({}) { |hash, status| hash[status] = status.to_s; hash },
+         default: PROCESSING.to_s,
+         validate: true
+end
+```
+
+We define constants that hold the valid status values and use the return values of these definitions as elements of an array of statuses.
+We can later on use `reduce` on this array when defining the enum to construct a `Hash` that maps symbol statuses to strings.
+This ensures that we have only a single place that we need to modify when adding, deleting or changing the possible statuses.
+
 ## The values quirk
 There’s one quirk, you’ve probably already noticed: `transform_values(&:to_s)`. I was quite confused what’s going on when I’ve provided symbols as values initially. Let’s see how the code looked like before:
 

--- a/posts/2024-03-29-replace-aasm-with-rails-enum-today.md
+++ b/posts/2024-03-29-replace-aasm-with-rails-enum-today.md
@@ -297,4 +297,27 @@ Occurrences of `Model.aasm.states.map(&:name)` are replaceable by `Model.statuse
 `Model.aasm.states_for_select` helper can be replaced with `Model.statuses.values.map { |name, value| [I18n.l(name), value] }`. Extract this to one of your helpers.
 Maybe you don’t need to call `I18n` at all and simple `humanize` will be enough.
 
+Keep in mind that when you are not migrating from aasm but creating a brand new field with some kind of statuses
+it would a better idea to map the values to integers and create a field like:
+
+```ruby
+add_column :transactions, :status, :integer, limit: 1
+```
+
+This will require less space in the DB to store the same amount of information.
+
+```ruby
+class Transaction < ApplicationRecord
+    enum :status,
+         [
+             PROCESSING = :processing,
+             FAILED = :failed,
+             SUCCESSFUL = :successful,
+             CANCELED = :canceled,
+         ],
+         default: PROCESSING,
+         validate: true
+end
+```
+
 Now it’s your turn.


### PR DESCRIPTION
I noticed that the proposed solution has unnecessary boilerplate that could make refactoring harder.

I added an additional example that has less boilerplate.